### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ import myImage from "src/path/to/image.jpg";
 <Image src={myImage} ..otherProps />
 <Picture src={myImage} ..otherProps />
 
-But the annyoing part is that each image has to be imported like above, and these can only be used in an astro component, or passed to a React component as a child. 
+But the annoying part is that each image has to be imported like above, and these can only be used in an astro component, or passed to a React component as a child. 
 
 Currently I just use full sized images everywhere. To help with the old bandwidth I have converted them to webp with ImageMagick.
 


### PR DESCRIPTION
## Summary
- fix a typo in the README for the images section

## Testing
- `npm run check-filenames`


------
https://chatgpt.com/codex/tasks/task_e_683f4fba6d78832082f18e91f0bfe6a7