### PR TITLE
Fix filename cleanup scripts

### DIFF
--- a/check-filenames.sh
+++ b/check-filenames.sh
@@ -13,3 +13,4 @@ fi
 
 echo "✓ No files with spaces found in names"
 exit 0
+

--- a/remove_spaces_from_filename.sh
+++ b/remove_spaces_from_filename.sh
@@ -28,6 +28,6 @@ process_file() {
 
 # Find and process all files recursively
 export -f process_file
-find "$1" -type f -name "* *" -exec bash -c 'process_file "$0"' {} \;
+find "$1" -type f -name "* *" -exec bash -c 'process_file "$1"' _ {} \;
 
 echo "Filename cleanup complete!"


### PR DESCRIPTION
## Summary
- fix quoting in remove_spaces_from_filename.sh
- add missing newlines at end of filename cleanup scripts

## Testing
- `npm ci`
- `npm run build` *(fails: Shiki warnings; build incomplete)*

------
https://chatgpt.com/codex/tasks/task_e_683f4c859acc8320b0006d42d29b4efc