### PR TITLE
Add recursive image processing and large file linter

### DIFF
--- a/check_large_files.sh
+++ b/check_large_files.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Fail if any file larger than 2MB exists in the repo (excluding node_modules and dist)
+
+LARGE_FILES=$(find . -type f -size +2M -not -path './node_modules/*' -not -path './dist/*' -not -path './.git/*')
+
+if [ -n "$LARGE_FILES" ]; then
+    echo "Error: Found files larger than 2MB:" >&2
+    echo "$LARGE_FILES" >&2
+    exit 1
+fi
+
+echo "✓ No files larger than 2MB found"
+exit 0


### PR DESCRIPTION
## Summary
- extend `compress_resize_images.sh` to work recursively and skip small images
- add `check_large_files.sh` script to fail when big files are present

## Testing
- `bash check-filenames.sh`
- `bash check_large_files.sh | head` *(fails: found files larger than 2MB)*

------
https://chatgpt.com/codex/tasks/task_e_683f835b69748320854615a658decfb5