### PR TITLE
Fix binder page FC import

### DIFF
--- a/src/components/react/TypeSelector/TypeSelector.tsx
+++ b/src/components/react/TypeSelector/TypeSelector.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import type { FC } from 'react';
 import styles from './TypeSelector.module.scss';
 
 interface TypeSelectorProps {


### PR DESCRIPTION
## Summary
- fix `FC` import type issue that caused the dev build of `/experiments/binder` to fail

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_683fee630e1483208210de13643fff3b