### PR TITLE
Fix lint errors and adjust TypeScript types

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+node_modules
+public
+src/images
+src/assets
+src/content

--- a/src/components/react/Binder/Binder.tsx
+++ b/src/components/react/Binder/Binder.tsx
@@ -3,10 +3,16 @@ import styles from './Binder.module.scss';
 import Button from '../Button/Button';
 import { calculateBearing, findNearestBin } from '../../../utils/locationUtils';
 import { requestOrientationPermission } from '../../../utils/devicePermissions';
-import { getUniqueTypes, getFacilitiesByType } from '../../../utils/geoJsonLoader';
+import {
+  getUniqueTypes,
+  getFacilitiesByType,
+} from '../../../utils/geoJsonLoader';
 import { getCrimeData } from '../../../utils/crimeDataLoader';
 import { getTreeData } from '../../../utils/treeDataLoader';
-import { getGeneralTreeData, type GeneralTree } from '../../../utils/generalTreeDataLoader';
+import {
+  getGeneralTreeData,
+  type GeneralTree,
+} from '../../../utils/generalTreeDataLoader';
 import React from 'react';
 import Map from '../Map/Map';
 import DataTypeSelector from './DataTypeSelector/DataTypeSelector';
@@ -15,39 +21,56 @@ import { getLocationsForType } from './utils';
 import Dot from './Dot/Dot';
 import ZoomControls from './ZoomControls/ZoomControls';
 
-const DATASOURCES = ['Facilities', 'Crimes', 'Protected Trees', 'Trees'] as const;
-type DataSourceType = typeof DATASOURCES[number];
+const DATASOURCES = [
+  'Facilities',
+  'Crimes',
+  'Protected Trees',
+  'Trees',
+] as const;
+type DataSourceType = (typeof DATASOURCES)[number];
 
 const Binder = () => {
-  const [userLocation, setUserLocation] = useState<GeolocationCoordinates | null>(null);
+  const [userLocation, setUserLocation] =
+    useState<GeolocationCoordinates | null>(null);
   const [compass, setCompass] = useState<number>(0);
   const [distance, setDistance] = useState<number | null>(null);
   const [permissionGranted, setPermissionGranted] = useState(false);
   const [facilityTypes] = useState(() => getUniqueTypes());
   const [selectedType, setSelectedType] = useState(facilityTypes[0]);
-  const [locations, setLocations] = useState(() => getFacilitiesByType(facilityTypes[0]));
+  const [locations, setLocations] = useState(() =>
+    getFacilitiesByType(facilityTypes[0])
+  );
   const [currentBin, setCurrentBin] = useState(locations[0]);
   const [error, setError] = useState<string | null>(null);
-  const [showDotInfo, setShowDotInfo] = useState(false);
+  const [showDotInfo, setShowDotInfo] = useState<string | boolean>(false);
   const [showAllNearby, setShowAllNearby] = useState(false);
-  const [nearbyLocations, setNearbyLocations] = useState<Array<{
-    bin: typeof locations[0],
-    distance: number,
-    bearing: number
-  }>>([]);
-  const [dataType, setDataType] = useState<'facilities' | 'crimes' | 'protected trees' | 'trees'>('facilities');
+  const [nearbyLocations, setNearbyLocations] = useState<
+    Array<{
+      bin: (typeof locations)[0];
+      distance: number;
+      bearing: number;
+    }>
+  >([]);
+  const [dataType, setDataType] = useState<
+    'facilities' | 'crimes' | 'protected trees' | 'trees'
+  >('facilities');
   const [crimeLocations] = useState(() => getCrimeData());
   const [treeLocations] = useState(() => getTreeData());
-  const [generalTreeLocations, setGeneralTreeLocations] = useState<GeneralTree[]>([]);
+  const [generalTreeLocations, setGeneralTreeLocations] = useState<
+    GeneralTree[]
+  >([]);
   const [lockNorth, setLockNorth] = useState(false);
-  const [isDebugMode] = useState(() => 
-    typeof window !== 'undefined' && 
-    !('ontouchstart' in window) && 
-    process.env.NODE_ENV === 'development'
+  const [isDebugMode] = useState(
+    () =>
+      typeof window !== 'undefined' &&
+      !('ontouchstart' in window) &&
+      process.env.NODE_ENV === 'development'
   );
   const [mapZoom, setMapZoom] = useState(17); // Default zoom level 17
 
-  const updateLocations = (sorted: Array<{ bin: any, distance: number, bearing: number }>) => {
+  const updateLocations = (
+    sorted: Array<{ bin: any; distance: number; bearing: number }>
+  ) => {
     setNearbyLocations(sorted);
     setCurrentBin(sorted[0].bin);
     setDistance(sorted[0].distance);
@@ -71,7 +94,8 @@ const Binder = () => {
 
   useEffect(() => {
     if (userLocation && locations.length > 0) {
-      const sorted = locations.map(bin => findNearestBin(userLocation, [bin]))
+      const sorted = locations
+        .map((bin) => findNearestBin(userLocation, [bin]))
         .sort((a, b) => a.distance - b.distance)
         .slice(0, 10);
 
@@ -97,11 +121,18 @@ const Binder = () => {
         sorted = getLocationsForType(generalTreeLocations, userLocation);
         break;
     }
-    
+
     if (sorted) {
       updateLocations(sorted);
     }
-  }, [locations, userLocation, dataType, crimeLocations, treeLocations, generalTreeLocations]);
+  }, [
+    locations,
+    userLocation,
+    dataType,
+    crimeLocations,
+    treeLocations,
+    generalTreeLocations,
+  ]);
 
   useEffect(() => {
     const loadGeneralTrees = async () => {
@@ -112,14 +143,13 @@ const Binder = () => {
   }, []);
 
   const handleOrientation = (event: DeviceOrientationEvent) => {
-    const angle = event.webkitCompassHeading || event.alpha || 0;
+    const angle = (event as any).webkitCompassHeading || event.alpha || 0;
     setCompass(angle);
   };
 
   const requestPermissions = async () => {
-    await requestOrientationPermission(
-      handleOrientation,
-      () => setPermissionGranted(true)
+    await requestOrientationPermission(handleOrientation, () =>
+      setPermissionGranted(true)
     );
   };
 
@@ -159,30 +189,30 @@ const Binder = () => {
       altitude: null,
       altitudeAccuracy: null,
       heading: null,
-      speed: null
+      speed: null,
     };
-    
+
     setUserLocation(mockPosition);
   };
 
   // Calculate bearing based on active navigation mode
   let bearing = 0;
-  
+
   if (userLocation) {
     if (currentBin) {
       // Point to facility otherwise
       bearing = calculateBearing(userLocation, currentBin);
     }
   }
-  
+
   // Calculate final rotation with compass adjustment
-  const rotation = compass ? (bearing - compass) : bearing;
+  const rotation = compass ? bearing - compass : bearing;
 
   return (
     <div onClick={handleBackgroundClick}>
       <div className={styles.titleContainer}>
         <span>Find the closest</span>
-        <DataTypeSelector 
+        <DataTypeSelector
           dataType={dataType}
           onDataTypeChange={(type) => setDataType(type as typeof dataType)}
           facilityTypes={facilityTypes}
@@ -208,30 +238,32 @@ const Binder = () => {
           </label>
         </div>
       </div>
-      
+
       <div className={styles.container}>
         {error && <div className={styles.error}>{error}</div>}
 
         {!permissionGranted ? (
-          <Button id="enable-compass" onClick={requestPermissions} label="Enable Compass" />
+          <Button
+            id="enable-compass"
+            onClick={requestPermissions}
+            label="Enable Compass"
+          />
         ) : (
           <>
             <div className={styles.zoomControls}>
-              <ZoomControls 
-                zoom={mapZoom} 
-                onZoomChange={setMapZoom} 
-                min={11} 
-                max={20} 
+              <ZoomControls
+                zoom={mapZoom}
+                onZoomChange={setMapZoom}
+                min={11}
+                max={20}
                 step={1}
                 label="Map Zoom"
               />
             </div>
             <div className={styles.radar}>
-              <Map 
+              <Map
                 userLocation={userLocation}
-                currentLocation={ 
-                  currentBin
-                }
+                currentLocation={currentBin}
                 compass={compass}
                 lockNorth={lockNorth}
                 debugMode={isDebugMode}
@@ -239,9 +271,9 @@ const Binder = () => {
                 onDebugPositionChange={handleDebugPositionChange} // Add this prop
                 mapZoom={mapZoom}
               />
-              
+
               {/* Only show facility dots when not in SVG navigation mode */}
-              {showAllNearby && (
+              {showAllNearby &&
                 nearbyLocations.map((loc, index) => (
                   <Dot
                     key={loc.bin.id}
@@ -254,9 +286,8 @@ const Binder = () => {
                     onDotClick={handleDotClick}
                     mapZoom={mapZoom}
                   />
-                ))
-              )}
-              
+                ))}
+
               {!showAllNearby && currentBin && distance && (
                 <Dot
                   loc={{ bin: currentBin, distance, bearing }}
@@ -266,11 +297,11 @@ const Binder = () => {
                   compass={compass}
                   isNorthLocked={lockNorth}
                   onDotClick={handleDotClick}
-                  mapZoom={mapZoom} 
+                  mapZoom={mapZoom}
                 />
               )}
             </div>
-            
+
             <svg
               className={styles.arrow}
               style={{ transform: `rotate(${rotation}deg)` }}
@@ -282,10 +313,10 @@ const Binder = () => {
             >
               <path d="m 106.15699,104.81898 0.81766,137.66811 102.24487,52.63857 L 106.09742,1.2562312 1.2008898,295.02942 96.460978,247.10502" />
             </svg>
-            
-            <DistanceDisplay 
-              name={currentBin?.name || ''} 
-              distance={distance} 
+
+            <DistanceDisplay
+              name={currentBin?.name || ''}
+              distance={distance}
             />
           </>
         )}
@@ -295,4 +326,3 @@ const Binder = () => {
 };
 
 export default Binder;
-

--- a/src/components/react/Binder/Dot/Dot.tsx
+++ b/src/components/react/Binder/Dot/Dot.tsx
@@ -9,7 +9,7 @@ interface DotProps {
     bearing: number;
   };
   isNearest: boolean;
-  showDotInfo?: boolean;
+  showDotInfo?: string | boolean;
   dataType: string;
   compass: number;
   isNorthLocked: boolean;
@@ -18,28 +18,29 @@ interface DotProps {
 }
 
 export const getDotPosition = (
-  distance: number, 
-  bearing: number, 
-  isNorthLocked: boolean, 
+  distance: number,
+  bearing: number,
+  isNorthLocked: boolean,
   compass: number,
   mapZoom: number = 17
 ) => {
   const radius = 150;
-  
+
   // Replace switch statement with a general formula that works for any zoom level
   // Use 17 as reference zoom with scale factor 1.0
   // Each zoom level difference changes scale by factor of 2
   const zoomDifference = 17 - mapZoom;
   const scalingFactor = Math.pow(2, zoomDifference);
-  
+
   const maxDistance = radius * scalingFactor;
   const rotatedBearing = isNorthLocked ? bearing : bearing - compass;
   const angle = ((rotatedBearing - 90) * Math.PI) / 180;
-  const scaledDistance = Math.min(distance, maxDistance) * (radius / maxDistance);
-  
+  const scaledDistance =
+    Math.min(distance, maxDistance) * (radius / maxDistance);
+
   return {
     left: `${radius + scaledDistance * Math.cos(angle)}px`,
-    top: `${radius + scaledDistance * Math.sin(angle)}px`
+    top: `${radius + scaledDistance * Math.sin(angle)}px`,
   };
 };
 
@@ -51,7 +52,7 @@ const Dot: React.FC<DotProps> = ({
   compass,
   isNorthLocked,
   onDotClick,
-  mapZoom = 17
+  mapZoom = 17,
 }) => {
   const position = getDotPosition(
     loc.distance,
@@ -63,7 +64,7 @@ const Dot: React.FC<DotProps> = ({
 
   return (
     <React.Fragment key={loc.bin.id}>
-      <div 
+      <div
         className={`${styles.dot} ${isNearest ? styles.nearest : ''}`}
         style={position}
         onClick={(e) => onDotClick(e, loc.bin.id)}
@@ -71,7 +72,7 @@ const Dot: React.FC<DotProps> = ({
         tabIndex={0}
       />
       {showDotInfo === loc.bin.id && (
-        <div 
+        <div
           className={styles.dotInfo}
           style={position}
           onClick={(e) => e.stopPropagation()}

--- a/src/components/react/CanvasMapGenerator/Canvas.tsx
+++ b/src/components/react/CanvasMapGenerator/Canvas.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react'
+import React, { useRef, useEffect } from 'react';
 import { createNoise2D } from 'simplex-noise';
 import alea from 'alea';
 
@@ -19,18 +19,26 @@ let noise2D = createNoise2D(prng);
  * You can install it with npm install perlin.js
  *
  */
-function drawLakes(ctx, player) {
+function drawLakes(
+  ctx: CanvasRenderingContext2D,
+  player: { x: number; y: number }
+) {
   ctx.fillStyle = 'blue';
-  for (let x = player.x; x < NUMBER_OF_TILES; x+=TILE_WIDTH) {
-    for (let y = player.y; y < NUMBER_OF_TILES; y+=TILE_WIDTH) {
-      if (noise2D(x , y ) > 0.2) {
-        ctx.fillRect(x * TILE_WIDTH - player.x, y * TILE_WIDTH - player.y, TILE_WIDTH, TILE_WIDTH);
+  for (let x = player.x; x < NUMBER_OF_TILES; x += TILE_WIDTH) {
+    for (let y = player.y; y < NUMBER_OF_TILES; y += TILE_WIDTH) {
+      if (noise2D(x, y) > 0.2) {
+        ctx.fillRect(
+          x * TILE_WIDTH - player.x,
+          y * TILE_WIDTH - player.y,
+          TILE_WIDTH,
+          TILE_WIDTH
+        );
       }
     }
   }
 }
 
-function fillMapWithGreen (ctx) {
+function fillMapWithGreen(ctx: CanvasRenderingContext2D) {
   ctx.fillStyle = 'green';
   for (let x = 0; x < NUMBER_OF_TILES; x++) {
     for (let y = 0; y < NUMBER_OF_TILES; y++) {
@@ -39,20 +47,20 @@ function fillMapWithGreen (ctx) {
   }
 }
 
-
-const Canvas =({reRenderTrigger}: {reRenderTrigger: number}) => {
+const Canvas = ({ reRenderTrigger }: { reRenderTrigger: number }) => {
   const [player, updatePlayer] = React.useState({ x: 0, y: 0 });
   const [frameCount, updateFrameCount] = React.useState(0);
 
   noise2D = createNoise2D(alea(reRenderTrigger));
   useEffect(() => {
     const canvas = canvasRef.current;
-    const context = canvas.getContext('2d');
-    let animationFrameId;
+    const context = canvas?.getContext('2d');
+    let animationFrameId: number;
     const render = () => {
-       //updateFrameCount(frameCount + 1);
-       updatePlayer({ x: frameCount*TILE_WIDTH, y: 0 });
-      draw(context, frameCount);
+      updatePlayer({ x: frameCount * TILE_WIDTH, y: 0 });
+      if (context) {
+        draw(context, frameCount);
+      }
       animationFrameId = window.requestAnimationFrame(render);
     };
     render();
@@ -61,16 +69,21 @@ const Canvas =({reRenderTrigger}: {reRenderTrigger: number}) => {
     };
   }, [frameCount, reRenderTrigger]);
 
-  const canvasRef = useRef(null)
-  const draw = (ctx, frameCount) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const draw = (ctx: CanvasRenderingContext2D, frameCount: number) => {
     ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
 
     fillMapWithGreen(ctx);
     drawLakes(ctx, player);
   };
 
-
-
-  return <canvas className={styles.canvas} width={JSON.stringify(MAP_WIDTH) + "px"} height={JSON.stringify(MAP_WIDTH) + "px"} ref={canvasRef} />;
-}
-export default Canvas
+  return (
+    <canvas
+      className={styles.canvas}
+      width={JSON.stringify(MAP_WIDTH) + 'px'}
+      height={JSON.stringify(MAP_WIDTH) + 'px'}
+      ref={canvasRef}
+    />
+  );
+};
+export default Canvas;

--- a/src/components/react/Images/ImageContainer.tsx
+++ b/src/components/react/Images/ImageContainer.tsx
@@ -1,64 +1,65 @@
-
 import { useEffect, useState } from 'react';
 import styles from './ImageContainer.module.css';
 
 interface ImageContainerProps {
-    src: string;
-    id: string;
-    isExpanded?: boolean;
+  src: string;
+  id: string;
+  isExpanded?: boolean;
 }
 
-const ImageContainer = ({src, id, isExpanded = false}: ImageContainerProps) => {
-    const defaultStyles = {
-        width: "100%",
-        height: "auto",
+const ImageContainer = ({
+  src,
+  id,
+  isExpanded = false,
+}: ImageContainerProps) => {
+  const defaultStyles: React.CSSProperties = {
+    width: '100%',
+    height: 'auto',
+    minHeight: '20vh',
+    maxHeight: '70vh',
+    objectFit: 'cover',
+    border: '20px solid white',
+    outline: '2px solid whitesmoke',
+    transition: 'all 0.6s ease-in-out',
+    objectPosition: '33% 33%',
+    maxWidth: '100vw',
+  };
+  const [isZoomedView, setIsZoomedView] = useState(isExpanded);
+  const [imgStyles, setImgStyles] = useState<React.CSSProperties>({
+    ...defaultStyles,
+  });
+
+  useEffect(() => {
+    if (isZoomedView === true) {
+      setImgStyles({
+        width: '90vw',
+        height: 'auto',
         minHeight: '20vh',
-        maxHeight: '70vh',
+        maxHeight: '90vh',
         objectFit: 'cover',
+        transition: 'all 0.6s ease-in-out',
         border: '20px solid white',
         outline: '2px solid whitesmoke',
-        transition: 'all 0.6s ease-in-out',
-        objectPosition: '33% 33%',
+        objectPosition: '66% 33%',
         maxWidth: '100vw',
-
+      });
+    } else {
+      setImgStyles({
+        ...defaultStyles,
+      });
     }
-    const [isZoomedView, setIsZoomedView] = useState(isExpanded);
-    const [imgStyles, setImgStyles] = useState({...defaultStyles});
+  }, [isZoomedView]);
 
-  
-
-    useEffect(() => {
-
-        if (isZoomedView === true ) {
-            
-            setImgStyles({
-                width: '90vw',
-                height: 'auto',
-                minHeight: '20vh',
-                maxHeight: '90vh',
-                objectFit: 'cover',
-                transition: 'all 0.6s ease-in-out',
-                border: '20px solid white',
-                outline: '2px solid whitesmoke',
-                objectPosition: '66% 33%',
-                maxWidth: '100vw',
-
-            })
-
-        }
-
-        else {
-            setImgStyles({
-                ...defaultStyles
-            })}
-        }, [isZoomedView]);
-
-    
-
-return (
-<div className={styles.imageContainer} onClick={() => {setIsZoomedView(!isZoomedView)}}>
-<img src={src} style={{...imgStyles}} id={id} />
-</div>)
-}
+  return (
+    <div
+      className={styles.imageContainer}
+      onClick={() => {
+        setIsZoomedView(!isZoomedView);
+      }}
+    >
+      <img src={src} style={{ ...imgStyles }} id={id} />
+    </div>
+  );
+};
 
 export default ImageContainer;

--- a/src/components/react/Map/Map.tsx
+++ b/src/components/react/Map/Map.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import L from 'leaflet';
 import styles from './Map.module.scss';
 
 interface MapProps {
@@ -12,15 +13,15 @@ interface MapProps {
   mapZoom?: number;
 }
 
-const Map = ({ 
-  userLocation, 
-  currentLocation, 
-  compass, 
+const Map = ({
+  userLocation,
+  currentLocation,
+  compass,
   lockNorth,
   debugMode = false,
   onDebugCompass,
   onDebugPositionChange,
-  mapZoom = 17
+  mapZoom = 17,
 }: MapProps) => {
   const mapRef = useRef<L.Map | null>(null);
   const markerRef = useRef<L.Marker | null>(null);
@@ -36,14 +37,11 @@ const Map = ({
         doubleClickZoom: false,
         boxZoom: false,
         keyboard: false,
-      }).setView(
-        [userLocation.latitude, userLocation.longitude],
-        mapZoom
-      );
+      }).setView([userLocation.latitude, userLocation.longitude], mapZoom);
 
       L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         maxZoom: 19,
-        attribution: '© OpenStreetMap contributors'
+        attribution: '© OpenStreetMap contributors',
       }).addTo(mapRef.current);
 
       // Create user marker with draggable option if in debug mode
@@ -52,31 +50,38 @@ const Map = ({
         {
           icon: L.divIcon({
             className: styles.userMarker,
-            html: '<div></div>'
+            html: '<div></div>',
           }),
-          draggable: debugMode // Make marker draggable in debug mode
+          draggable: debugMode, // Make marker draggable in debug mode
         }
       )
-      .bindPopup(() => {
-        const content = document.createElement('div');
-        content.className = styles.userPopup;
-        content.innerHTML = `
+        .bindPopup(
+          () => {
+            const content = document.createElement('div');
+            content.className = styles.userPopup;
+            content.innerHTML = `
           <h3>Your Location</h3>
           <p>Lat: ${userLocation.latitude.toFixed(6)}</p>
           <p>Lng: ${userLocation.longitude.toFixed(6)}</p>
           <p>Accuracy: ${userLocation.accuracy.toFixed(1)}m</p>
-          ${userLocation.altitude ? `<p>Altitude: ${userLocation.altitude.toFixed(1)}m</p>` : ''}
+          ${
+            userLocation.altitude
+              ? `<p>Altitude: ${userLocation.altitude.toFixed(1)}m</p>`
+              : ''
+          }
         `;
-        return content;
-      }, {
-        closeButton: false,
-        className: styles.popup
-      })
-      .addTo(mapRef.current);
+            return content;
+          },
+          {
+            closeButton: false,
+            className: styles.popup,
+          }
+        )
+        .addTo(mapRef.current);
 
       // Add drag end event listener for debug mode
       if (debugMode && onDebugPositionChange) {
-        userMarkerRef.current.on('dragend', function() {
+        userMarkerRef.current.on('dragend', function () {
           const position = userMarkerRef.current?.getLatLng();
           if (position) {
             onDebugPositionChange(position.lat, position.lng);
@@ -88,14 +93,17 @@ const Map = ({
     // Update map rotation based on compass - reset to 0 when locked to north
     if (mapRef.current) {
       const mapContainer = mapRef.current.getContainer();
-      mapContainer.style.transform = lockNorth ? 
-        'rotate(0deg)' : 
-        `rotate(-${compass}deg)`;
+      mapContainer.style.transform = lockNorth
+        ? 'rotate(0deg)'
+        : `rotate(-${compass}deg)`;
     }
 
     // Update user location and center
     if (mapRef.current && userLocation && userMarkerRef.current) {
-      const newLatLng = [userLocation.latitude, userLocation.longitude] as [number, number];
+      const newLatLng = [userLocation.latitude, userLocation.longitude] as [
+        number,
+        number
+      ];
       userMarkerRef.current.setLatLng(newLatLng);
       mapRef.current.setView(newLatLng, mapZoom, { animate: false });
     }
@@ -110,8 +118,8 @@ const Map = ({
         {
           icon: L.divIcon({
             className: styles.destinationMarker,
-            html: '<div></div>'
-          })
+            html: '<div></div>',
+          }),
         }
       ).addTo(mapRef.current);
     }
@@ -147,7 +155,7 @@ const Map = ({
             />
             <span>{Math.round(compass)}°</span>
           </div>
-          
+
           <div className={styles.debugInfo}>
             <h4>Debug Mode</h4>
             <p>Drag the blue marker to change your position</p>

--- a/src/components/react/Strava/Strava.tsx
+++ b/src/components/react/Strava/Strava.tsx
@@ -2,95 +2,124 @@ import { useState, useEffect } from 'react';
 import styles from './Strava.module.scss';
 import AnimatedBobUp from '../animations/AnimatedBobUp';
 import Button from '../Button/Button';
-import { calculateBearing, calculateDistance } from '../../../utils/locationUtils';
+import {
+  calculateBearing,
+  calculateDistance,
+} from '../../../utils/locationUtils';
 import { requestOrientationPermission } from '../../../utils/devicePermissions';
 import React from 'react';
 import Map from '../Map/Map';
 import { getDotPosition } from '../Binder/Dot/Dot';
 import ZoomControls from '../Binder/ZoomControls/ZoomControls';
-import { processSVGPath, type PathPoint, type SVGPathMetadata } from '../../../utils/svgPathUtils';
+import {
+  processSVGPath,
+  type PathPoint,
+  type SVGPathMetadata,
+} from '../../../utils/svgPathUtils';
 import SVGControlsOverlay from '../Binder/SVGControlsOverlay/SVGControlsOverlay';
 
 const Strava = () => {
-  const [userLocation, setUserLocation] = useState<GeolocationCoordinates | null>(null);
+  const [userLocation, setUserLocation] =
+    useState<GeolocationCoordinates | null>(null);
   const [compass, setCompass] = useState<number>(0);
   const [permissionGranted, setPermissionGranted] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [lockNorth, setLockNorth] = useState(false);
-  const [isDebugMode] = useState(() => 
-    typeof window !== 'undefined' && 
-    !('ontouchstart' in window) && 
-    process.env.NODE_ENV === 'development'
+  const [isDebugMode] = useState(
+    () =>
+      typeof window !== 'undefined' &&
+      !('ontouchstart' in window) &&
+      process.env.NODE_ENV === 'development'
   );
   const [mapZoom, setMapZoom] = useState(17); // Default zoom level 17
-  
+
   // SVG-specific state
   const [svgPathPoints, setSvgPathPoints] = useState<PathPoint[]>([]);
   const [svgMinDistance, setSvgMinDistance] = useState(10);
   const [svgMaxDistance, setSvgMaxDistance] = useState(20);
   const [showSvgPath, setShowSvgPath] = useState(true);
   const [svgMaxPoints] = useState(1000);
-  const [currentSvgContent, setCurrentSvgContent] = useState<string | null>(null);
+  const [currentSvgContent, setCurrentSvgContent] = useState<string | null>(
+    null
+  );
   const [svgScale, setSvgScale] = useState(1.0);
   const [currentGoalIndex, setCurrentGoalIndex] = useState<number>(0);
-  const [svgAnchorLocation, setSvgAnchorLocation] = useState<{latitude: number, longitude: number} | null>(null);
+  const [svgAnchorLocation, setSvgAnchorLocation] = useState<{
+    latitude: number;
+    longitude: number;
+  } | null>(null);
   const [svgRotation, setSvgRotation] = useState(0);
   const [showSvgOptions, setShowSvgOptions] = useState(false);
   const [overlayPosition, setOverlayPosition] = useState({ x: 0, y: 0 });
-  const [svgMetadata, setSvgMetadata] = useState<SVGPathMetadata>({ 
-    totalDistanceMeters: 0, 
-    averagePointDistanceMeters: 0, 
-    pointsCount: 0 
+  const [svgMetadata, setSvgMetadata] = useState<SVGPathMetadata>({
+    totalDistanceMeters: 0,
+    averagePointDistanceMeters: 0,
+    pointsCount: 0,
   });
   const [limitVisiblePoints, setLimitVisiblePoints] = useState(false);
 
   // Re-process SVG when parameters change
   useEffect(() => {
     if (!currentSvgContent || (!userLocation && !svgAnchorLocation)) return;
-    
+
     // Use either the anchor location (if set) or the current user location
     const anchorPoint = svgAnchorLocation || userLocation!;
-    
+
     const result = processSVGPath(
-      currentSvgContent, 
-      anchorPoint.latitude, 
-      anchorPoint.longitude, 
+      currentSvgContent,
+      anchorPoint.latitude,
+      anchorPoint.longitude,
       {
         minDistanceMeters: svgMinDistance,
         maxDistanceMeters: svgMaxDistance,
         maxPoints: svgMaxPoints,
         svgScale: svgScale,
-        svgRotation: svgRotation
+        svgRotation: svgRotation,
       }
     );
-    
+
     setSvgPathPoints(result.points);
     setSvgMetadata(result.metadata);
-    
-    console.log(`SVG path total distance: ${result.metadata.totalDistanceMeters.toFixed(2)}m`);
-  }, [currentSvgContent, svgAnchorLocation, svgMinDistance, svgMaxDistance, svgMaxPoints, svgScale, svgRotation, userLocation]);
+
+    console.log(
+      `SVG path total distance: ${result.metadata.totalDistanceMeters.toFixed(
+        2
+      )}m`
+    );
+  }, [
+    currentSvgContent,
+    svgAnchorLocation,
+    svgMinDistance,
+    svgMaxDistance,
+    svgMaxPoints,
+    svgScale,
+    svgRotation,
+    userLocation,
+  ]);
 
   // Check if user is near the current goal dot
   useEffect(() => {
     if (userLocation && svgPathPoints.length > 0 && showSvgPath) {
       // Use order property to find the next incomplete point
-      const orderedPoints = [...svgPathPoints].sort((a, b) => a.order - b.order);
-      const currentGoalPoint = orderedPoints.find(point => !point.completed);
-      
-      if (!currentGoalPoint) return; // All dots completed
-      
-      // Calculate distance to current goal dot
-      const distanceToGoal = calculateDistance(
-        userLocation,
-        { latitude: currentGoalPoint.latitude, longitude: currentGoalPoint.longitude }
+      const orderedPoints = [...svgPathPoints].sort(
+        (a, b) => a.order - b.order
       );
-      
+      const currentGoalPoint = orderedPoints.find((point) => !point.completed);
+
+      if (!currentGoalPoint) return; // All dots completed
+
+      // Calculate distance to current goal dot
+      const distanceToGoal = calculateDistance(userLocation, {
+        latitude: currentGoalPoint.latitude,
+        longitude: currentGoalPoint.longitude,
+      });
+
       // If user is within 5 meters, mark this dot as completed
       if (distanceToGoal < 5) {
-        setSvgPathPoints(prevPoints => 
-          prevPoints.map(point => 
-            point.id === currentGoalPoint.id 
-              ? { ...point, completed: true } 
+        setSvgPathPoints((prevPoints) =>
+          prevPoints.map((point) =>
+            point.id === currentGoalPoint.id
+              ? { ...point, completed: true }
               : point
           )
         );
@@ -99,14 +128,13 @@ const Strava = () => {
   }, [userLocation, svgPathPoints, showSvgPath]);
 
   const handleOrientation = (event: DeviceOrientationEvent) => {
-    const angle = event.webkitCompassHeading || event.alpha || 0;
+    const angle = (event as any).webkitCompassHeading || event.alpha || 0;
     setCompass(angle);
   };
 
   const requestPermissions = async () => {
-    await requestOrientationPermission(
-      handleOrientation,
-      () => setPermissionGranted(true)
+    await requestOrientationPermission(handleOrientation, () =>
+      setPermissionGranted(true)
     );
   };
 
@@ -136,22 +164,22 @@ const Strava = () => {
       altitude: null,
       altitudeAccuracy: null,
       heading: null,
-      speed: null
+      speed: null,
     };
-    
+
     setUserLocation(mockPosition);
   };
 
   const handleSVGImport = (svgContent: string) => {
     if (userLocation) {
       setCurrentSvgContent(svgContent);
-      
+
       // Set the anchor point to current user location
       setSvgAnchorLocation({
         latitude: userLocation.latitude,
-        longitude: userLocation.longitude
+        longitude: userLocation.longitude,
       });
-      
+
       // Reset the goal index and ensure path is visible
       setCurrentGoalIndex(0);
       setShowSvgPath(true);
@@ -164,7 +192,7 @@ const Strava = () => {
     if (userLocation) {
       setSvgAnchorLocation({
         latitude: userLocation.latitude,
-        longitude: userLocation.longitude
+        longitude: userLocation.longitude,
       });
     }
   };
@@ -181,61 +209,62 @@ const Strava = () => {
     setLimitVisiblePoints(value);
   };
 
-  const handleOverlayPositionChange = (position: { x: number, y: number }) => {
+  const handleOverlayPositionChange = (position: { x: number; y: number }) => {
     setOverlayPosition(position);
   };
 
   // Add handler to manually mark current goal as completed
   const handleSkipCurrentGoal = () => {
     if (!currentGoalDot) return;
-    
-    setSvgPathPoints(prevPoints => 
-      prevPoints.map(point => 
-        point.id === currentGoalDot.id 
-          ? { ...point, completed: true } 
-          : point
+
+    setSvgPathPoints((prevPoints) =>
+      prevPoints.map((point) =>
+        point.id === currentGoalDot.id ? { ...point, completed: true } : point
       )
     );
   };
 
   // Find the current goal dot and determine SVG navigation mode
   const orderedSvgPoints = [...svgPathPoints].sort((a, b) => a.order - b.order);
-  const currentGoalDot = orderedSvgPoints.find(point => !point.completed);
-  const completedCount = svgPathPoints.filter(point => point.completed).length;
+  const currentGoalDot = orderedSvgPoints.find((point) => !point.completed);
+  const completedCount = svgPathPoints.filter(
+    (point) => point.completed
+  ).length;
   const totalCount = svgPathPoints.length;
-  const isSvgNavigationActive = showSvgPath && svgPathPoints.length > 0 && currentGoalDot;
-  
+  const isSvgNavigationActive =
+    showSvgPath && svgPathPoints.length > 0 && currentGoalDot;
+
   // Calculate bearing to current goal
   let bearing = 0;
-  
+
   if (userLocation && isSvgNavigationActive && currentGoalDot) {
-    bearing = calculateBearing(
-      userLocation, 
-      { latitude: currentGoalDot.latitude, longitude: currentGoalDot.longitude }
-    );
+    bearing = calculateBearing(userLocation, {
+      latitude: currentGoalDot.latitude,
+      longitude: currentGoalDot.longitude,
+    });
   }
-  
+
   // Calculate final rotation with compass adjustment
-  const rotation = compass ? (bearing - compass) : bearing;
+  const rotation = compass ? bearing - compass : bearing;
 
   // Determine which points to render based on limitVisiblePoints setting
   let pointsToRender = orderedSvgPoints;
-  
+
   if (limitVisiblePoints && currentGoalDot) {
     // Find the index of current goal dot
-    const currentGoalIndex = orderedSvgPoints.findIndex(point => point.id === currentGoalDot.id);
-    
+    const currentGoalIndex = orderedSvgPoints.findIndex(
+      (point) => point.id === currentGoalDot.id
+    );
+
     // Select only the next 3 points (including current goal)
     pointsToRender = orderedSvgPoints.slice(
-      currentGoalIndex, 
+      currentGoalIndex,
       currentGoalIndex + 3
     );
-    
+
     // Always include completed points
-    const completedPoints = orderedSvgPoints.filter(point => point.completed);
+    const completedPoints = orderedSvgPoints.filter((point) => point.completed);
     pointsToRender = [...completedPoints, ...pointsToRender];
-    
-  
   }
 
   return (
@@ -243,19 +272,17 @@ const Strava = () => {
       <div className={styles.titleContainer}>
         <p>Upload an SVG and turn it into a running path</p>
         <div className={styles.toggleContainer}>
-       
-          <button 
-            className={styles.svgButton} 
-            onClick={handleShowSvgControls}
-          >
+          <button className={styles.svgButton} onClick={handleShowSvgControls}>
             SVG Path Tools
           </button>
         </div>
       </div>
-      
+
       {svgPathPoints.length > 0 && showSvgPath && (
         <div className={styles.svgProgress}>
-          <span>Progress: {completedCount}/{totalCount} points</span>
+          <span>
+            Progress: {completedCount}/{totalCount} points
+          </span>
           <div className={styles.progressBar}>
             <div
               className={styles.progressFill}
@@ -264,30 +291,38 @@ const Strava = () => {
           </div>
         </div>
       )}
-      
+
       <div className={styles.container}>
         {error && <div className={styles.error}>{error}</div>}
 
         {!permissionGranted ? (
-          <Button id="enable-compass" onClick={requestPermissions} label="Enable Compass" />
+          <Button
+            id="enable-compass"
+            onClick={requestPermissions}
+            label="Enable Compass"
+          />
         ) : (
           <>
             <div className={styles.zoomControls}>
-              <ZoomControls 
-                zoom={mapZoom} 
-                onZoomChange={setMapZoom} 
-                min={11} 
-                max={20} 
+              <ZoomControls
+                zoom={mapZoom}
+                onZoomChange={setMapZoom}
+                min={11}
+                max={20}
                 step={1}
                 label="Map Zoom"
               />
             </div>
             <div className={styles.radar}>
-              <Map 
+              <Map
                 userLocation={userLocation}
-                currentLocation={currentGoalDot ? 
-                  { latitude: currentGoalDot.latitude, longitude: currentGoalDot.longitude } : 
-                  null
+                currentLocation={
+                  currentGoalDot
+                    ? {
+                        latitude: currentGoalDot.latitude,
+                        longitude: currentGoalDot.longitude,
+                      }
+                    : null
                 }
                 compass={compass}
                 lockNorth={lockNorth}
@@ -296,34 +331,38 @@ const Strava = () => {
                 onDebugPositionChange={handleDebugPositionChange}
                 mapZoom={mapZoom}
               />
-              
+
               {/* SVG path dots */}
-              {showSvgPath && userLocation && pointsToRender.map((point) => (
-                <div
-                  key={`svg-${point.id}`}
-                  className={`
+              {showSvgPath &&
+                userLocation &&
+                pointsToRender.map((point) => (
+                  <div
+                    key={`svg-${point.id}`}
+                    className={`
                     ${styles.dot} 
                     ${styles.svgDot} 
                     ${point.completed ? styles.completedDot : ''} 
                     ${point === currentGoalDot ? styles.goalDot : ''}
                   `}
-                  style={getDotPosition(
-                    calculateDistance(
-                      userLocation, 
-                      { latitude: point.latitude, longitude: point.longitude }
-                    ),
-                    calculateBearing(
-                      userLocation, 
-                      { latitude: point.latitude, longitude: point.longitude }
-                    ),
-                    lockNorth,
-                    compass,
-                    mapZoom
-                  )}
-                  title={`Point ${point.order}${point.completed ? ' (Completed)' : ''}`}
-                />
-              ))}
-              
+                    style={getDotPosition(
+                      calculateDistance(userLocation, {
+                        latitude: point.latitude,
+                        longitude: point.longitude,
+                      }),
+                      calculateBearing(userLocation, {
+                        latitude: point.latitude,
+                        longitude: point.longitude,
+                      }),
+                      lockNorth,
+                      compass,
+                      mapZoom
+                    )}
+                    title={`Point ${point.order}${
+                      point.completed ? ' (Completed)' : ''
+                    }`}
+                  />
+                ))}
+
               {/* SVG controls overlay */}
               {showSvgOptions && (
                 <SVGControlsOverlay
@@ -348,7 +387,7 @@ const Strava = () => {
                 />
               )}
             </div>
-            
+
             <AnimatedBobUp>
               <svg
                 className={styles.arrow}
@@ -362,10 +401,10 @@ const Strava = () => {
                 <path d="m 106.15699,104.81898 0.81766,137.66811 102.24487,52.63857 L 106.09742,1.2562312 1.2008898,295.02942 96.460978,247.10502" />
               </svg>
             </AnimatedBobUp>
-            
+
             {/* Add skip button below arrow when in SVG navigation mode */}
             {isSvgNavigationActive && (
-              <button 
+              <button
                 className={styles.skipGoalButton}
                 onClick={handleSkipCurrentGoal}
                 title="Mark this point as completed without physically reaching it"
@@ -373,14 +412,20 @@ const Strava = () => {
                 Skip Goal
               </button>
             )}
-            
+
             {/* Show goal information */}
             {isSvgNavigationActive && userLocation && (
               <div className={styles.goalInfo}>
-                <span>Next goal: {Math.round(calculateDistance(
-                  userLocation,
-                  { latitude: currentGoalDot.latitude, longitude: currentGoalDot.longitude }
-                ))}m</span>
+                <span>
+                  Next goal:{' '}
+                  {Math.round(
+                    calculateDistance(userLocation, {
+                      latitude: currentGoalDot.latitude,
+                      longitude: currentGoalDot.longitude,
+                    })
+                  )}
+                  m
+                </span>
               </div>
             )}
           </>

--- a/src/components/react/TypeSelector/TypeSelector.tsx
+++ b/src/components/react/TypeSelector/TypeSelector.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import type { FC } from 'react';
 import styles from './TypeSelector.module.scss';
 
 interface TypeSelectorProps {
@@ -7,14 +7,18 @@ interface TypeSelectorProps {
   onTypeChange: (type: string) => void;
 }
 
-const TypeSelector: FC<TypeSelectorProps> = ({ types, selectedType, onTypeChange }) => {
+const TypeSelector: FC<TypeSelectorProps> = ({
+  types,
+  selectedType,
+  onTypeChange,
+}) => {
   return (
-    <select 
+    <select
       className={styles.selector}
       value={selectedType}
       onChange={(e) => onTypeChange(e.target.value)}
     >
-      {types.map(type => (
+      {types.map((type) => (
         <option key={type} value={type}>
           {type}
         </option>

--- a/src/pages/api/trees.json.ts
+++ b/src/pages/api/trees.json.ts
@@ -4,46 +4,57 @@ import path from 'path';
 
 export const GET: APIRoute = async () => {
   try {
-    const filePath = path.join(process.cwd(), 'public', 'bristol-data', 'Trees.json');
+    const filePath = path.join(
+      process.cwd(),
+      'public',
+      'bristol-data',
+      'Trees.json'
+    );
     const rawData = await fs.readFile(filePath, 'utf-8');
     const data = JSON.parse(rawData);
 
-
     const processedTrees = data.features
-      .filter(feature => 
-        feature.geometry?.coordinates && 
-        Array.isArray(feature.geometry.coordinates) &&
-        feature.geometry.coordinates.length === 2
+      .filter(
+        (feature: any) =>
+          feature.geometry?.coordinates &&
+          Array.isArray(feature.geometry.coordinates) &&
+          feature.geometry.coordinates.length === 2
       )
-      .map(feature => ({
+      .map((feature: any) => ({
         id: `tree-${feature.properties.ASSET_ID}`,
-        name: feature.properties.COMMON_NAME || feature.properties.SPECIES || 'Unknown Tree',
+        name:
+          feature.properties.COMMON_NAME ||
+          feature.properties.SPECIES ||
+          'Unknown Tree',
         latitude: feature.geometry.coordinates[1],
         longitude: feature.geometry.coordinates[0],
         species: feature.properties.TREE_SPECIES || 'Unknown',
-        commonName: feature.properties.FULL_COMMON_NAME || feature.properties.COMMON_NAME || 'Unknown',
+        commonName:
+          feature.properties.FULL_COMMON_NAME ||
+          feature.properties.COMMON_NAME ||
+          'Unknown',
         latinName: feature.properties.LATIN_NAME || 'Unknown',
         height: feature.properties.CROWN_HEIGHT || 0,
         crownWidth: feature.properties.CROWN_WIDTH || 0,
         age: feature.properties.AGE_DESC || 'Unknown',
         condition: feature.properties.CONDITION || 'Unknown',
-        deadFlag: feature.properties.DEAD_FLAG || 'Unknown'
+        deadFlag: feature.properties.DEAD_FLAG || 'Unknown',
       }));
 
     return new Response(JSON.stringify(processedTrees), {
       status: 200,
       headers: {
         'Content-Type': 'application/json',
-        'Cache-Control': 'public, max-age=3600' // Cache for 1 hour
-      }
+        'Cache-Control': 'public, max-age=3600', // Cache for 1 hour
+      },
     });
   } catch (error) {
     console.error('Error processing tree data:', error);
     return new Response(JSON.stringify({ error: 'Failed to load tree data' }), {
       status: 500,
       headers: {
-        'Content-Type': 'application/json'
-      }
+        'Content-Type': 'application/json',
+      },
     });
   }
 };

--- a/src/utils/collisionDataLoader.ts
+++ b/src/utils/collisionDataLoader.ts
@@ -2,7 +2,9 @@ import collisionData from '../assets/bristol-data/Traffic_collisions.json';
 
 export interface CollisionLocation {
   id: string;
-  coordinates: [number, number];
+  name: string;
+  latitude: number;
+  longitude: number;
   date: string;
   time: string;
   severity: string;
@@ -18,30 +20,27 @@ export interface CollisionLocation {
 }
 
 export function getCollisionData(): CollisionLocation[] {
-  return collisionData.features
-    .map((feature, index) => {
-      const lat = feature.geometry.coordinates[1];
-      const lng = feature.geometry.coordinates[0];
+  return collisionData.features.map((feature: any, index: number) => {
+    const lat = feature.geometry.coordinates[1];
+    const lng = feature.geometry.coordinates[0];
 
-
-      return {
-        id: `collision-${index}`,
-        name:feature.properties.ACCIDENT_DESCRIPTION,
-        latitude: lat,
-        longitude: lng,
-        date: feature.properties.DATE_,
-        time: feature.properties.TIME,
-        severity: feature.properties.SEVERITY_DESCRIPTION,
-        accidentType: feature.properties.ACCIDENT_TYPE,
-        accidentDescription: feature.properties.ACCIDENT_DESCRIPTION,
-        vehicles: feature.properties.VEHICLES,
-        casualties: feature.properties.CASUALTIES,
-        pedestrians: feature.properties.PEDESTRIAN,
-        cycles: feature.properties.CYCLES,
-        motorcycles: feature.properties.MCYCLES,
-        children: feature.properties.CHILDREN,
-        elderly: feature.properties.OAPS
-      };
-    })
-    .filter((item): item is CollisionLocation => item !== null); // Remove any null entries
+    return {
+      id: `collision-${index}`,
+      name: feature.properties.ACCIDENT_DESCRIPTION,
+      latitude: lat,
+      longitude: lng,
+      date: feature.properties.DATE_,
+      time: feature.properties.TIME,
+      severity: feature.properties.SEVERITY_DESCRIPTION,
+      accidentType: feature.properties.ACCIDENT_TYPE,
+      accidentDescription: feature.properties.ACCIDENT_DESCRIPTION,
+      vehicles: feature.properties.VEHICLES,
+      casualties: feature.properties.CASUALTIES,
+      pedestrians: feature.properties.PEDESTRIAN,
+      cycles: feature.properties.CYCLES,
+      motorcycles: feature.properties.MCYCLES,
+      children: feature.properties.CHILDREN,
+      elderly: feature.properties.OAPS,
+    };
+  }) as CollisionLocation[];
 }

--- a/src/utils/devicePermissions.ts
+++ b/src/utils/devicePermissions.ts
@@ -4,9 +4,11 @@ export const requestOrientationPermission = async (
   onOrientationChange: OrientationCallback,
   onPermissionGranted: () => void
 ): Promise<void> => {
-  if (typeof DeviceOrientationEvent.requestPermission === 'function') {
+  if (typeof (DeviceOrientationEvent as any).requestPermission === 'function') {
     try {
-      const permission = await DeviceOrientationEvent.requestPermission();
+      const permission = await (
+        DeviceOrientationEvent as any
+      ).requestPermission();
       if (permission === 'granted') {
         window.addEventListener('deviceorientation', onOrientationChange);
         onPermissionGranted();

--- a/src/utils/geoJsonLoader.ts
+++ b/src/utils/geoJsonLoader.ts
@@ -5,6 +5,7 @@ export interface Facility {
   properties: {
     TYPE: string;
     SITE_NAME: string;
+    [key: string]: any;
   };
   geometry: {
     type: string;
@@ -17,29 +18,30 @@ export const loadFacilities = (): Facility[] => {
     console.error('Failed to load facilities data');
     return [];
   }
-  return facilitiesData.features;
+  return facilitiesData.features as unknown as Facility[];
 };
 
 export const getUniqueTypes = (): string[] => {
   const facilities = loadFacilities();
-  const types = new Set(facilities.map(f => f.properties.TYPE));
+  const types = new Set(facilities.map((f) => f.properties.TYPE));
   return Array.from(types).sort();
 };
 
 export const getFacilitiesByType = (type: string) => {
   const facilities = loadFacilities();
   return facilities
-    .filter(f => 
-      f?.properties?.TYPE === type && 
-      f?.geometry?.coordinates && 
-      Array.isArray(f.geometry.coordinates) &&
-      f.geometry.coordinates.length === 2
+    .filter(
+      (f) =>
+        f?.properties?.TYPE === type &&
+        f?.geometry?.coordinates &&
+        Array.isArray(f.geometry.coordinates) &&
+        f.geometry.coordinates.length === 2
     )
-    .map(f => ({
+    .map((f) => ({
       latitude: f.geometry.coordinates[1],
       longitude: f.geometry.coordinates[0],
       name: f.properties.SITE_NAME || f.properties.TYPE,
-      id: f.properties.ASSET_ID || `facility-${Math.random()}`
+      id: f.properties.ASSET_ID || `facility-${Math.random()}`,
     }))
-    .filter(f => !isNaN(f.latitude) && !isNaN(f.longitude));
+    .filter((f) => !isNaN(f.latitude) && !isNaN(f.longitude));
 };


### PR DESCRIPTION
## Summary
- add .prettierignore so prettier skips large asset folders
- update TypeScript code to satisfy `tsc --noEmit`
- include fixes for DeviceOrientation types, Leaflet imports and other small issues

## Testing
- `npx prettier --write $(cat /tmp/target_files_without_ignore.txt)`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_683feedf15cc8320993ea6b3bd8fdc00