### PR TITLE
Add Navigator experiment

### DIFF
--- a/src/components/react/Binder/Binder.module.scss
+++ b/src/components/react/Binder/Binder.module.scss
@@ -11,17 +11,6 @@
   overflow: hidden;
 }
 
-.arrow {
-  width: 100px;
-  height: auto;
-  transform-origin: center;
-  transition: transform 0.1s ease-out;
-  stroke: $arrowBlue;
-
-  // add glow to arrow svg that has 30% opacity
-  filter: drop-shadow(0 0 4px rgba(51, 102, 205, 0.33));
-}
-
 .error {
   color: #d32f2f;
   padding: 8px;

--- a/src/components/react/Binder/Binder.tsx
+++ b/src/components/react/Binder/Binder.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../../utils/generalTreeDataLoader';
 import React from 'react';
 import Map from '../Map/Map';
+import NavigationArrow from '../NavigationArrow/NavigationArrow';
 import DataTypeSelector from './DataTypeSelector/DataTypeSelector';
 import DistanceDisplay from './DistanceDisplay/DistanceDisplay';
 import { getLocationsForType } from './utils';
@@ -315,17 +316,7 @@ const Binder = () => {
               )}
             </div>
 
-            <svg
-              className={styles.arrow}
-              style={{ transform: `rotate(${rotation}deg)` }}
-              viewBox="0 0 210 297"
-              width="100"
-              height="100"
-              fill="none"
-              strokeWidth="6"
-            >
-              <path d="m 106.15699,104.81898 0.81766,137.66811 102.24487,52.63857 L 106.09742,1.2562312 1.2008898,295.02942 96.460978,247.10502" />
-            </svg>
+            <NavigationArrow rotation={rotation} />
 
             <DistanceDisplay
               name={currentBin?.name || ''}

--- a/src/components/react/NavigationArrow/NavigationArrow.module.scss
+++ b/src/components/react/NavigationArrow/NavigationArrow.module.scss
@@ -1,0 +1,10 @@
+@import '../../../styles/colors';
+
+.arrow {
+  width: 100px;
+  height: auto;
+  transform-origin: center;
+  transition: transform 0.1s ease-out;
+  stroke: $arrowBlue;
+  filter: drop-shadow(0 0 4px rgba(51, 102, 205, 0.33));
+}

--- a/src/components/react/NavigationArrow/NavigationArrow.tsx
+++ b/src/components/react/NavigationArrow/NavigationArrow.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import AnimatedBobUp from '../animations/AnimatedBobUp';
+import styles from './NavigationArrow.module.scss';
+
+interface NavigationArrowProps {
+  rotation: number;
+  className?: string;
+}
+
+const NavigationArrow: React.FC<NavigationArrowProps> = ({
+  rotation,
+  className,
+}) => (
+  <AnimatedBobUp>
+    <svg
+      className={`${styles.arrow} ${className ?? ''}`}
+      style={{ transform: `rotate(${rotation}deg)` }}
+      viewBox="0 0 210 297"
+      width="100"
+      height="100"
+      fill="none"
+      strokeWidth="6"
+    >
+      <path d="m 106.15699,104.81898 0.81766,137.66811 102.24487,52.63857 L 106.09742,1.2562312 1.2008898,295.02942 96.460978,247.10502" />
+    </svg>
+  </AnimatedBobUp>
+);
+
+export default NavigationArrow;

--- a/src/components/react/Navigator/Navigator.module.scss
+++ b/src/components/react/Navigator/Navigator.module.scss
@@ -1,0 +1,44 @@
+@import '../../../styles/colors';
+
+.container {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  background: #f5f5f5;
+  overflow: hidden;
+}
+
+.inputRow {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.input {
+  padding: 0.5rem;
+}
+
+.error {
+  color: #d32f2f;
+  padding: 8px;
+  margin: 8px 0;
+  border-radius: 4px;
+  background-color: #ffebee;
+  border: 1px solid #ffcdd2;
+}
+
+.radar {
+  position: relative;
+  width: 300px;
+  height: 300px;
+  border-radius: 50%;
+  border: 2px solid rgba(51, 102, 205, 0.2);
+}
+
+.distance {
+  margin-top: 0.5rem;
+  font-size: 1.2rem;
+}

--- a/src/components/react/Navigator/Navigator.tsx
+++ b/src/components/react/Navigator/Navigator.tsx
@@ -1,0 +1,116 @@
+import { useState, useEffect } from 'react';
+import React from 'react';
+import styles from './Navigator.module.scss';
+import Button from '../Button/Button';
+import Map from '../Map/Map';
+import NavigationArrow from '../NavigationArrow/NavigationArrow';
+import {
+  calculateBearing,
+  calculateDistance,
+} from '../../../utils/locationUtils';
+import { requestOrientationPermission } from '../../../utils/devicePermissions';
+
+const Navigator = () => {
+  const [userLocation, setUserLocation] =
+    useState<GeolocationCoordinates | null>(null);
+  const [compass, setCompass] = useState<number>(0);
+  const [permissionGranted, setPermissionGranted] = useState(false);
+  const [target, setTarget] = useState<{
+    latitude: number;
+    longitude: number;
+  } | null>(null);
+  const [inputValue, setInputValue] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [lockNorth, setLockNorth] = useState(false);
+  const [mapZoom, setMapZoom] = useState(17);
+
+  const handleOrientation = (event: DeviceOrientationEvent) => {
+    const orientation = event as DeviceOrientationEvent & {
+      webkitCompassHeading?: number;
+    };
+    const angle = orientation.webkitCompassHeading ?? orientation.alpha ?? 0;
+    setCompass(angle);
+  };
+
+  const requestPermissions = async () => {
+    await requestOrientationPermission(handleOrientation, () =>
+      setPermissionGranted(true)
+    );
+  };
+
+  useEffect(() => {
+    navigator.geolocation.watchPosition(
+      (pos) => setUserLocation(pos.coords),
+      (err) => console.error('Error getting location:', err),
+      { enableHighAccuracy: true }
+    );
+
+    return () => {
+      window.removeEventListener('deviceorientation', handleOrientation);
+    };
+  }, []);
+
+  const handleGo = () => {
+    const parts = inputValue.split(',').map((p) => p.trim());
+    if (parts.length === 2) {
+      const lat = parseFloat(parts[0]);
+      const lng = parseFloat(parts[1]);
+      if (!isNaN(lat) && !isNaN(lng)) {
+        setTarget({ latitude: lat, longitude: lng });
+        setError(null);
+        return;
+      }
+    }
+    setError('Invalid coordinates. Use "lat,lng"');
+  };
+
+  let bearing = 0;
+  let distance: number | null = null;
+  if (userLocation && target) {
+    bearing = calculateBearing(userLocation, target);
+    distance = calculateDistance(userLocation, target);
+  }
+
+  const rotation = compass ? bearing - compass : bearing;
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.inputRow}>
+        <input
+          type="text"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          placeholder="lat,lng"
+          className={styles.input}
+        />
+        <Button id="go" onClick={handleGo} label="GO" />
+      </div>
+      {error && <div className={styles.error}>{error}</div>}
+      {!permissionGranted ? (
+        <Button
+          id="enable-compass"
+          onClick={requestPermissions}
+          label="Enable Compass"
+        />
+      ) : (
+        <>
+          <div className={styles.radar}>
+            <Map
+              userLocation={userLocation}
+              currentLocation={target}
+              compass={compass}
+              lockNorth={lockNorth}
+              mapZoom={mapZoom}
+            />
+          </div>
+          <NavigationArrow rotation={rotation} />
+          {distance !== null && (
+            <div className={styles.distance}>{Math.round(distance)}m</div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default Navigator;

--- a/src/components/react/Strava/Strava.module.scss
+++ b/src/components/react/Strava/Strava.module.scss
@@ -11,15 +11,6 @@
   overflow: hidden;
 }
 
-.arrow {
-  width: 100px;
-  height: auto;
-  transform-origin: center;
-  transition: transform 0.1s ease-out;
-  stroke: $arrowBlue;
-  filter: drop-shadow(0 0 4px rgba(51, 102, 205, 0.33));
-}
-
 .error {
   color: #d32f2f;
   padding: 8px;

--- a/src/components/react/Strava/Strava.tsx
+++ b/src/components/react/Strava/Strava.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import styles from './Strava.module.scss';
-import AnimatedBobUp from '../animations/AnimatedBobUp';
+import NavigationArrow from '../NavigationArrow/NavigationArrow';
 import Button from '../Button/Button';
 import {
   calculateBearing,
@@ -394,19 +394,7 @@ const Strava = () => {
               )}
             </div>
 
-            <AnimatedBobUp>
-              <svg
-                className={styles.arrow}
-                style={{ transform: `rotate(${rotation}deg)` }}
-                viewBox="0 0 210 297"
-                width="100"
-                height="100"
-                fill="none"
-                strokeWidth="6"
-              >
-                <path d="m 106.15699,104.81898 0.81766,137.66811 102.24487,52.63857 L 106.09742,1.2562312 1.2008898,295.02942 96.460978,247.10502" />
-              </svg>
-            </AnimatedBobUp>
+            <NavigationArrow rotation={rotation} />
 
             {/* Add skip button below arrow when in SVG navigation mode */}
             {isSvgNavigationActive && (

--- a/src/components/react/Title/Title.tsx
+++ b/src/components/react/Title/Title.tsx
@@ -53,6 +53,9 @@ export const Title = ({ title }: { title: string }) => {
           <a href="/experiments/binder" className={styles.subtitleText}>
             Binder
           </a>
+          <a href="/experiments/navigator" className={styles.subtitleText}>
+            Navigator
+          </a>
           {false && (
             <a href="/about" className={styles.subtitleText}>
               About

--- a/src/pages/experiments/navigator.mdx
+++ b/src/pages/experiments/navigator.mdx
@@ -1,0 +1,14 @@
+---
+layout: '../../layouts/BaseLayout.astro'
+date: '2024-05-15'
+title: 'Navigator'
+tags: ['experiment']
+---
+
+import DummyComponent from '../../components/DummyComponent/DummyComponent.astro';
+
+<DummyComponent />
+
+import Navigator from '../../components/react/Navigator/Navigator.tsx';
+
+<Navigator client:only />


### PR DESCRIPTION
## Summary
- create `Navigator` component to navigate to a coordinate using phone sensors
- factor shared arrow into `NavigationArrow` component with bobbing animation
- replace arrow uses in Binder and Strava with new component
- add Navigator page and link in site navigation

## Testing
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840303bef348320bcbf823d15adfa5b